### PR TITLE
Update the main slide to have a bold header

### DIFF
--- a/slides/Slides.md
+++ b/slides/Slides.md
@@ -6,7 +6,7 @@ theme: custom-dark
 transition: glow
 ---
 
-# GitHub Copilot Quickstart
+# **GitHub Copilot Quickstart**
 ![bg fit right:40%](./img/ghcp.jpg)
 
 ---

--- a/slides/themes/custom-default.css
+++ b/slides/themes/custom-default.css
@@ -11,6 +11,7 @@ body {
 
 h1 {
   font-size: 90px;  /* Adjust the size as needed */
+  font-weight: bold; /* Make h1 headers bold */
   /* Other styling properties like font-family, color, etc., can also be added here */
 }
 


### PR DESCRIPTION
Related to #5

Update the main slide to have a bold header.

* Modify `slides/themes/custom-default.css` to add a CSS rule making `h1` headers bold.
* Update `slides/Slides.md` to use `# **GitHub Copilot Quickstart**` for the main slide header.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jmgress/github-copilot/issues/5?shareId=c6d2c07f-5e4b-4840-96b6-18496e9e8140).